### PR TITLE
[fix] retrofit 객체에 대한 순환 의존성 해결 

### DIFF
--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/di/NetworkModule.kt
@@ -5,6 +5,8 @@ import com.capstone.lovemarker.core.network.authenticator.LoveMarkerAuthenticato
 import com.capstone.lovemarker.core.network.interceptor.AuthInterceptor
 import com.capstone.lovemarker.core.network.qualifier.Auth
 import com.capstone.lovemarker.core.network.qualifier.Logging
+import com.capstone.lovemarker.core.network.qualifier.AuthRequired
+import com.capstone.lovemarker.core.network.qualifier.AuthNotRequired
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Binds
 import dagger.Module
@@ -57,6 +59,7 @@ object NetworkModule {
     @Provides
     fun provideAuthInterceptor(interceptor: AuthInterceptor): Interceptor = interceptor
 
+    @AuthRequired
     @Singleton
     @Provides
     fun provideOkHttpClient(
@@ -69,11 +72,33 @@ object NetworkModule {
         .authenticator(authenticator)
         .build()
 
+    @AuthNotRequired
+    @Singleton
+    @Provides
+    fun provideOkHttpClientAuthNotRequired(
+        @Logging logInterceptor: Interceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(logInterceptor)
+        .build()
+
+    @AuthRequired
     @Singleton
     @Provides
     fun provideRetrofit(
-        client: OkHttpClient,
+        @AuthRequired client: OkHttpClient,
         converterFactory: Converter.Factory
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.AUTH_BASE_URL)
+        .client(client)
+        .addConverterFactory(converterFactory)
+        .build()
+
+    @AuthNotRequired
+    @Singleton
+    @Provides
+    fun provideRetrofitAuthNotRequired(
+        @AuthNotRequired client: OkHttpClient,
+        converterFactory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(BuildConfig.AUTH_BASE_URL)
         .client(client)

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/di/ServiceModule.kt
@@ -1,0 +1,18 @@
+package com.capstone.lovemarker.core.network.di
+
+import com.capstone.lovemarker.core.network.service.ReissueTokenService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+    @Provides
+    @Singleton
+    fun provideReissueTokenService(retrofit: Retrofit): ReissueTokenService =
+        retrofit.create(ReissueTokenService::class.java)
+}

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/di/ServiceModule.kt
@@ -1,11 +1,13 @@
 package com.capstone.lovemarker.core.network.di
 
+import com.capstone.lovemarker.core.network.qualifier.AuthNotRequired
 import com.capstone.lovemarker.core.network.service.ReissueTokenService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -13,6 +15,6 @@ import javax.inject.Singleton
 object ServiceModule {
     @Provides
     @Singleton
-    fun provideReissueTokenService(retrofit: Retrofit): ReissueTokenService =
-        retrofit.create(ReissueTokenService::class.java)
+    fun provideReissueTokenService(@AuthNotRequired retrofit: Retrofit): ReissueTokenService =
+        retrofit.create()
 }

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/qualifier/Authentication.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/qualifier/Authentication.kt
@@ -1,0 +1,11 @@
+package com.capstone.lovemarker.core.network.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRequired
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthNotRequired

--- a/data/auth/src/main/java/com/capstone/lovemarker/auth/di/ServiceModule.kt
+++ b/data/auth/src/main/java/com/capstone/lovemarker/auth/di/ServiceModule.kt
@@ -6,6 +6,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -13,6 +14,5 @@ import javax.inject.Singleton
 object ServiceModule {
     @Provides
     @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService =
-        retrofit.create(AuthService::class.java)
+    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create()
 }

--- a/data/auth/src/main/java/com/capstone/lovemarker/auth/di/ServiceModule.kt
+++ b/data/auth/src/main/java/com/capstone/lovemarker/auth/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.capstone.lovemarker.auth.di
 
 import com.capstone.lovemarker.auth.service.AuthService
+import com.capstone.lovemarker.core.network.qualifier.AuthRequired
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -14,5 +15,5 @@ import javax.inject.Singleton
 object ServiceModule {
     @Provides
     @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create()
+    fun provideAuthService(@AuthRequired retrofit: Retrofit): AuthService = retrofit.create()
 }


### PR DESCRIPTION
## 📝 Work Description

- 순환 의존성 발생: Retrofit -> TokenService -> Authenticator -> OkHttpClient -> Retrofit 
- 토큰 재발급하는 api는 @AuthNotRequired 한정자로 retrofit 객체 주입 
- @AuthNotRequired retrofit 객체는 Authenticator에 대해 모르기 때문에 순환 의존성 해결 !! 
- 참고 레포: https://github.dev/TeamPophory/pophory-android
