### PR TITLE
[feat] 닉네임 변경 api 연결 

### DIFF
--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
@@ -12,21 +12,17 @@ class AuthInterceptor @Inject constructor(
     private val userPreferencesDataSource: UserPreferencesDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = runBlocking {
-            "Bearer ${userPreferencesDataSource.userData.first().accessToken}"
+        val userData = runBlocking {
+            userPreferencesDataSource.userData.first()
         }
-        val refreshToken = runBlocking {
-            userPreferencesDataSource.userData.first().refreshToken
-        }
-
-        Timber.d("Access Token: $accessToken")
-        Timber.d("Refresh Token: $refreshToken")
 
         val originalRequest = chain.request()
         val headerRequest = originalRequest.newBuilder()
-            .addHeader("Authorization", accessToken)
-            .addHeader("refreshToken", refreshToken)
+            .addHeader("accessToken", userData.accessToken)
+            .addHeader("refreshToken", userData.refreshToken)
             .build()
+
+        Timber.d("Headers: ${headerRequest.headers}")
 
         return chain.proceed(headerRequest)
     }

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
@@ -22,8 +22,6 @@ class AuthInterceptor @Inject constructor(
             .addHeader("refreshToken", userData.refreshToken)
             .build()
 
-        Timber.d("Headers: ${headerRequest.headers}")
-
         return chain.proceed(headerRequest)
     }
 }

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/interceptor/AuthInterceptor.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
+import timber.log.Timber
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
@@ -14,10 +15,17 @@ class AuthInterceptor @Inject constructor(
         val accessToken = runBlocking {
             "Bearer ${userPreferencesDataSource.userData.first().accessToken}"
         }
+        val refreshToken = runBlocking {
+            userPreferencesDataSource.userData.first().refreshToken
+        }
+
+        Timber.d("Access Token: $accessToken")
+        Timber.d("Refresh Token: $refreshToken")
 
         val originalRequest = chain.request()
         val headerRequest = originalRequest.newBuilder()
-            .header("Authorization", accessToken)
+            .addHeader("Authorization", accessToken)
+            .addHeader("refreshToken", refreshToken)
             .build()
 
         return chain.proceed(headerRequest)

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/model/BaseResponseNothing.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/model/BaseResponseNothing.kt
@@ -1,0 +1,14 @@
+package com.capstone.lovemarker.core.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponseNothing(
+    @SerialName("status")
+    val code: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+)

--- a/core/network/src/main/java/com/capstone/lovemarker/core/network/service/ReissueTokenService.kt
+++ b/core/network/src/main/java/com/capstone/lovemarker/core/network/service/ReissueTokenService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 
 interface ReissueTokenService {
-    @GET("/auth/reissue-token")
+    @GET("/api/auth/reissue-token")
     suspend fun getNewAccessToken(
         @Header("refreshToken") refreshToken: String,
     ): BaseResponse<ReissueTokenResponse>

--- a/data/auth/src/main/java/com/capstone/lovemarker/data/auth/service/AuthService.kt
+++ b/data/auth/src/main/java/com/capstone/lovemarker/data/auth/service/AuthService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthService {
-    @POST("api/auth")
+    @POST("/api/auth")
     suspend fun postLogin(
         @Body requestBody: LoginRequest,
     ): BaseResponse<LoginResponse>

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/dto/NicknameResponse.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/dto/NicknameResponse.kt
@@ -1,0 +1,21 @@
+package com.capstone.lovemarker.data.nickname.dto
+
+import com.capstone.lovemarker.domain.nickname.entity.NicknameEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NicknameResponse(
+    @SerialName("status")
+    val code: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+) {
+    fun toDomain() = NicknameEntity(
+        code = code,
+        success = success,
+        message = message
+    )
+}

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/repository/NicknameRepositoryImpl.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/repository/NicknameRepositoryImpl.kt
@@ -2,13 +2,13 @@ package com.capstone.lovemarker.data.nickname.repository
 
 import com.capstone.lovemarker.data.nickname.dto.NicknameRequest
 import com.capstone.lovemarker.data.nickname.source.NicknameDataSource
+import com.capstone.lovemarker.domain.nickname.entity.NicknameEntity
 import com.capstone.lovemarker.domain.nickname.repository.NicknameRepository
 import javax.inject.Inject
 
 class NicknameRepositoryImpl @Inject constructor(
     private val nicknameDataSource: NicknameDataSource,
 ) : NicknameRepository {
-    override suspend fun patchNickname(nickname: String): Result<Unit> = runCatching {
-        nicknameDataSource.patchNickname(NicknameRequest(nickname))
-    }
+    override suspend fun patchNickname(nickname: String): NicknameEntity =
+        nicknameDataSource.patchNickname(NicknameRequest(nickname)).toDomain()
 }

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/repository/NicknameRepositoryImpl.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/repository/NicknameRepositoryImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class NicknameRepositoryImpl @Inject constructor(
     private val nicknameDataSource: NicknameDataSource,
 ) : NicknameRepository {
-    override suspend fun patchNickname(nickname: String) = runCatching {
-        nicknameDataSource.patchNickname(NicknameRequest(nickname)).data
+    override suspend fun patchNickname(nickname: String): Result<Unit> = runCatching {
+        nicknameDataSource.patchNickname(NicknameRequest(nickname))
     }
 }

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Body
 import retrofit2.http.PATCH
 
 interface NicknameService {
-    @PATCH("user")
+    @PATCH("/api/user")
     suspend fun patchNickname(
         @Body nicknameRequest: NicknameRequest,
     ): BaseResponse<Unit>

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Body
 import retrofit2.http.PATCH
 
 interface NicknameService {
-    @PATCH("/api/user")
+    @PATCH("/api/user/nickname")
     suspend fun patchNickname(
         @Body nicknameRequest: NicknameRequest,
     ): BaseResponse<Unit>

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
@@ -1,7 +1,7 @@
 package com.capstone.lovemarker.data.nickname.service
 
-import com.capstone.lovemarker.core.network.model.BaseResponse
 import com.capstone.lovemarker.data.nickname.dto.NicknameRequest
+import com.capstone.lovemarker.core.network.model.BaseResponseNothing
 import retrofit2.http.Body
 import retrofit2.http.PATCH
 
@@ -9,5 +9,5 @@ interface NicknameService {
     @PATCH("/api/user/nickname")
     suspend fun patchNickname(
         @Body nicknameRequest: NicknameRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseNothing
 }

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/service/NicknameService.kt
@@ -2,6 +2,7 @@ package com.capstone.lovemarker.data.nickname.service
 
 import com.capstone.lovemarker.data.nickname.dto.NicknameRequest
 import com.capstone.lovemarker.core.network.model.BaseResponseNothing
+import com.capstone.lovemarker.data.nickname.dto.NicknameResponse
 import retrofit2.http.Body
 import retrofit2.http.PATCH
 
@@ -9,5 +10,5 @@ interface NicknameService {
     @PATCH("/api/user/nickname")
     suspend fun patchNickname(
         @Body nicknameRequest: NicknameRequest,
-    ): BaseResponseNothing
+    ): NicknameResponse
 }

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/source/NicknameDataSource.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/source/NicknameDataSource.kt
@@ -2,7 +2,8 @@ package com.capstone.lovemarker.data.nickname.source
 
 import com.capstone.lovemarker.data.nickname.dto.NicknameRequest
 import com.capstone.lovemarker.core.network.model.BaseResponseNothing
+import com.capstone.lovemarker.data.nickname.dto.NicknameResponse
 
 interface NicknameDataSource {
-    suspend fun patchNickname(nicknameRequest: NicknameRequest): BaseResponseNothing
+    suspend fun patchNickname(nicknameRequest: NicknameRequest): NicknameResponse
 }

--- a/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/source/NicknameDataSource.kt
+++ b/data/nickname/src/main/java/com/capstone/lovemarker/data/nickname/source/NicknameDataSource.kt
@@ -1,8 +1,8 @@
 package com.capstone.lovemarker.data.nickname.source
 
-import com.capstone.lovemarker.core.network.model.BaseResponse
 import com.capstone.lovemarker.data.nickname.dto.NicknameRequest
+import com.capstone.lovemarker.core.network.model.BaseResponseNothing
 
 interface NicknameDataSource {
-    suspend fun patchNickname(nicknameRequest: NicknameRequest): BaseResponse<Unit>
+    suspend fun patchNickname(nicknameRequest: NicknameRequest): BaseResponseNothing
 }

--- a/domain/nickname/src/main/java/com/capstone/lovemarker/domain/nickname/entity/NicknameEntity.kt
+++ b/domain/nickname/src/main/java/com/capstone/lovemarker/domain/nickname/entity/NicknameEntity.kt
@@ -1,0 +1,7 @@
+package com.capstone.lovemarker.domain.nickname.entity
+
+data class NicknameEntity(
+    val code: Int,
+    val success: Boolean,
+    val message: String
+)

--- a/domain/nickname/src/main/java/com/capstone/lovemarker/domain/nickname/repository/NicknameRepository.kt
+++ b/domain/nickname/src/main/java/com/capstone/lovemarker/domain/nickname/repository/NicknameRepository.kt
@@ -1,5 +1,7 @@
 package com.capstone.lovemarker.domain.nickname.repository
 
+import com.capstone.lovemarker.domain.nickname.entity.NicknameEntity
+
 interface NicknameRepository {
-    suspend fun patchNickname(nickname: String): Result<Unit>
+    suspend fun patchNickname(nickname: String): NicknameEntity
 }

--- a/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginScreen.kt
@@ -55,11 +55,12 @@ fun LoginRoute(
             .collectLatest { sideEffect ->
                 when (sideEffect) {
                     is LoginSideEffect.LoginSuccess -> {
-                        if (sideEffect.isRegistered) {
-                            navigateToMap()
-                        } else {
-                            navigateToNickname()
-                        }
+                        navigateToNickname()
+//                        if (sideEffect.isRegistered) {
+//                            navigateToMap()
+//                        } else {
+//                            navigateToNickname()
+//                        }
                     }
 
                     is LoginSideEffect.ShowErrorSnackbar -> {

--- a/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginViewModel.kt
@@ -35,6 +35,9 @@ class LoginViewModel @Inject constructor(
                         )
                     )
                     updateAutoLogin(configured = true)
+
+                    Timber.d("Server Access Token: ${response.accessToken}")
+                    Timber.d("Server Refresh Token: ${response.refreshToken}")
                 }
 
                 _loginSideEffect.emit(LoginSideEffect.LoginSuccess(response.isRegistered))

--- a/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/capstone/lovemarker/feature/login/LoginViewModel.kt
@@ -35,14 +35,12 @@ class LoginViewModel @Inject constructor(
                         )
                     )
                     updateAutoLogin(configured = true)
-
-                    Timber.d("Server Access Token: ${response.accessToken}")
-                    Timber.d("Server Refresh Token: ${response.refreshToken}")
                 }
 
                 _loginSideEffect.emit(LoginSideEffect.LoginSuccess(response.isRegistered))
-            }.onFailure {
-                _loginSideEffect.emit(LoginSideEffect.ShowErrorSnackbar(it))
+            }.onFailure { throwable ->
+                _loginSideEffect.emit(LoginSideEffect.ShowErrorSnackbar(throwable))
+                Timber.e(throwable.message)
             }
         }
     }

--- a/feature/main/src/main/java/com/capstone/lovemarker/feature/main/navigation/MainNavigator.kt
+++ b/feature/main/src/main/java/com/capstone/lovemarker/feature/main/navigation/MainNavigator.kt
@@ -20,7 +20,7 @@ class MainNavigator(
     private val currentDestination: NavDestination?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.Splash
+    val startDestination = Route.Login
 
     fun navigateToLogin(navOptions: NavOptions) {
         navController.navigateToLogin(navOptions)

--- a/feature/nickname/build.gradle.kts
+++ b/feature/nickname/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
     implementation(projects.domain.nickname)
+    implementation(libs.retrofit)
 }

--- a/feature/nickname/src/main/java/com/capstone/lovemarker/feature/nickname/NicknameViewModel.kt
+++ b/feature/nickname/src/main/java/com/capstone/lovemarker/feature/nickname/NicknameViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import timber.log.Timber
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -70,10 +70,14 @@ class NicknameViewModel @Inject constructor(
                     updateInputUiState(
                         InputUiState.Success
                     )
-                }.onFailure {
-                    updateInputUiState(
-                        InputUiState.Error.DUPLICATED
-                    )
+                }.onFailure { throwable ->
+                    if (throwable is HttpException && throwable.code() == CODE_NICKNAME_DUPLICATED) {
+                        updateInputUiState(
+                            InputUiState.Error.DUPLICATED
+                        )
+                    } else {
+                        _nicknameSideEffect.emit(NicknameSideEffect.ShowErrorSnackbar(throwable))
+                    }
                 }
         }
     }
@@ -102,5 +106,6 @@ class NicknameViewModel @Inject constructor(
 
     companion object {
         private const val REGEX_PATTERN = "^[0-9|a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣]*$"
+        private const val CODE_NICKNAME_DUPLICATED = 400
     }
 }


### PR DESCRIPTION
- #8

## 📝 Work Description 

- api path 변경 
- auth interceptor -> header 이름 변경 
- 서버에서 보내는 에러 메시지 기준으로 닉네임 중복 여부 확인 
